### PR TITLE
Feature/122 tabbar

### DIFF
--- a/BrocoliSe/BrocoliSe/Controller/SettingsViewController.swift
+++ b/BrocoliSe/BrocoliSe/Controller/SettingsViewController.swift
@@ -24,8 +24,8 @@ class SettingsViewController: UIViewController {
         navigationController?.navigationBar.isTranslucent = true
         navigationController?.navigationBar.barStyle = .default
         navigationController?.navigationBar.tintColor = .greenMedium
-        scene?.reloadTable()
         self.fetchUser()
+        scene?.reloadTable()
     }
     
     override func viewWillDisappear(_ animated: Bool) {

--- a/BrocoliSe/BrocoliSe/Coordinators/TabCoordinator.swift
+++ b/BrocoliSe/BrocoliSe/Coordinators/TabCoordinator.swift
@@ -42,12 +42,13 @@ class TabCoordinator: NSObject, TabCoordinatorProtocol {
     func configTabBar(color: UIColor) {
         tabBarController.tabBar.backgroundColor = color
         
+        let appearance = UITabBarAppearance()
+        appearance.configureWithTransparentBackground()
+        appearance.backgroundColor = .clear
+        
+        tabBarController.tabBar.standardAppearance = appearance
+        
         if #available(iOS 15.0, *) {
-            let appearance = UITabBarAppearance()
-            appearance.configureWithTransparentBackground()
-            appearance.backgroundColor = color
-            
-            tabBarController.tabBar.standardAppearance = appearance
             tabBarController.tabBar.scrollEdgeAppearance = self.tabBarController.tabBar.standardAppearance
         }
     }

--- a/BrocoliSe/BrocoliSe/View/Scenes/DiaryScene.swift
+++ b/BrocoliSe/BrocoliSe/View/Scenes/DiaryScene.swift
@@ -56,7 +56,7 @@ class DiaryScene: UIView {
     override init(frame: CGRect) {
         super.init(frame: frame)
      
-        backgroundColor = UIColor.backgroundColor
+        backgroundColor = UIColor.white
         dayActual = controller?.createToday()
         hierarchyView()
         setupConstraints()


### PR DESCRIPTION
## 📝 Descrição

Correção cor da TabBar em versões do iOS inferiores as 15. 
Correção da cor de background da tela inicial.

## 🔢 Tarefa relacionada

122 Corrigir tabbar no iOS15-

## 📱 Screenshots e GIFs

<img width="370" alt="Screen Shot 2021-11-08 at 09 31 53" src="https://user-images.githubusercontent.com/50965665/140742648-ba15ad28-6c00-47d7-a095-cdc0b722500e.png">

## ☑️ Tipo de mudança

- [x] ✅ Feature
- [ ] 🦟 BugFix
- [ ] 🚨 Hotfix
- [ ] 🚀 Release

## 🚨 Checklist 

- [x] Meu código compila normalmente
- [ ] Não existem warnings no lint
- [ ] Testes unitários

🖤 Obrigado! Você é lindo(a).PULL_REQUEST_TEMPLATE.md
